### PR TITLE
Add metadata editor interface

### DIFF
--- a/frontend/src/components/FileMetaDataEditorComponent.vue
+++ b/frontend/src/components/FileMetaDataEditorComponent.vue
@@ -13,7 +13,7 @@
           <font-awesome-icon icon="fa-regular fa-circle-xmark" />
         </button>
       </li>
-      <input type="text" class="flex-grow-1 border-0" @keyup.enter="addTag" />
+      <input type="text" class="flex-grow-1 border-0" placeholder="Author" @keyup.enter="addTag" />
     </ul>
     <input type="text" class="form-control" placeholder="filename" v-model="formModal.filename" />
   </div>
@@ -46,7 +46,8 @@ watch(
 async function addTag(event: Event) {
   event.preventDefault()
   const target = event.target as HTMLInputElement
-  if (target.value.length != 0) {
+  const value = target.value.trim()
+  if (value.length != 0) {
     formModal.value.authors.push(target.value)
     target.value = ''
   }

--- a/frontend/src/components/FileMetaDataEditorComponent.vue
+++ b/frontend/src/components/FileMetaDataEditorComponent.vue
@@ -13,7 +13,12 @@
           <font-awesome-icon icon="fa-regular fa-circle-xmark" />
         </button>
       </li>
-      <input type="text" class="flex-grow-1 border-0" placeholder="Author" @keyup.enter="addAuthor" />
+      <input
+        type="text"
+        class="flex-grow-1 border-0"
+        placeholder="Author"
+        @keyup.enter="addAuthor"
+      />
     </ul>
     <input type="text" class="form-control" placeholder="filename" v-model="formModal.filename" />
   </div>

--- a/frontend/src/components/FileMetaDataEditorComponent.vue
+++ b/frontend/src/components/FileMetaDataEditorComponent.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="d-flex flex-column" style="width: 20em">
+    <textarea
+      type="text"
+      class="form-control mb-2"
+      placeholder="Description"
+      v-model="formModal.description"
+    />
+    <ul class="form-control d-flex flex-wrap">
+      <li v-for="(author, index) in formModal.authors" class="px-1 m-1" :key="author">
+        {{ author }}
+        <button type="button" class="p-0 btn text-secondary" @click.prevent="deleteTag(index)">
+          <font-awesome-icon icon="fa-regular fa-circle-xmark" />
+        </button>
+      </li>
+      <input type="text" class="flex-grow-1 border-0" @keyup.enter="addTag" />
+    </ul>
+    <input type="text" class="form-control" placeholder="filename" v-model="formModal.filename" />
+  </div>
+</template>
+<script setup lang="ts">
+import type { FileMetadataForm, MetadataEditorFormType } from '@/constants'
+import { ref, watch, type Ref } from 'vue'
+const props = defineProps<{
+  metadata: FileMetadataForm
+}>()
+
+const formModal: Ref<MetadataEditorFormType> = ref({
+  description: props.metadata.description,
+  authors: props.metadata.authors,
+  filename: props.metadata.filename
+})
+
+const emit = defineEmits<{
+  updateForm: [MetadataEditorFormType]
+}>()
+
+watch(
+  formModal,
+  async (newValue) => {
+    emit('updateForm', newValue)
+  },
+  { deep: true }
+)
+
+async function addTag(event: Event) {
+  event.preventDefault()
+  const target = event.target as HTMLInputElement
+  if (target.value.length != 0) {
+    formModal.value.authors.push(target.value)
+    target.value = ''
+  }
+}
+
+async function deleteTag(index: number) {
+  formModal.value.authors = formModal.value.authors.filter((_, i) => i !== index)
+}
+</script>
+<style scoped>
+ul li {
+  color: #333;
+  list-style: none;
+  border-radius: 5px;
+  background: #f2f2f2;
+}
+
+ul input {
+  outline: none;
+  font-size: 16px;
+}
+</style>

--- a/frontend/src/components/FileMetaDataEditorComponent.vue
+++ b/frontend/src/components/FileMetaDataEditorComponent.vue
@@ -16,7 +16,7 @@
       <input
         type="text"
         class="flex-grow-1 border-0"
-        placeholder="Enter to input author"
+        :placeholder="formModal.authors.length == 0 ? 'One author per line, validate with ⏎' : ''"
         @keyup.enter="addAuthor"
       />
     </ul>

--- a/frontend/src/components/FileMetaDataEditorComponent.vue
+++ b/frontend/src/components/FileMetaDataEditorComponent.vue
@@ -9,11 +9,11 @@
     <ul class="form-control d-flex flex-wrap">
       <li v-for="(author, index) in formModal.authors" class="px-1 m-1" :key="author">
         {{ author }}
-        <button type="button" class="p-0 btn text-secondary" @click.prevent="deleteTag(index)">
+        <button type="button" class="p-0 btn text-secondary" @click.prevent="deleteAuthor(index)">
           <font-awesome-icon icon="fa-regular fa-circle-xmark" />
         </button>
       </li>
-      <input type="text" class="flex-grow-1 border-0" placeholder="Author" @keyup.enter="addTag" />
+      <input type="text" class="flex-grow-1 border-0" placeholder="Author" @keyup.enter="addAuthor" />
     </ul>
     <input type="text" class="form-control" placeholder="filename" v-model="formModal.filename" />
   </div>
@@ -43,7 +43,7 @@ watch(
   { deep: true }
 )
 
-async function addTag(event: Event) {
+async function addAuthor(event: Event) {
   event.preventDefault()
   const target = event.target as HTMLInputElement
   const value = target.value.trim()
@@ -53,7 +53,7 @@ async function addTag(event: Event) {
   }
 }
 
-async function deleteTag(index: number) {
+async function deleteAuthor(index: number) {
   formModal.value.authors = formModal.value.authors.filter((_, i) => i !== index)
 }
 </script>

--- a/frontend/src/components/FileMetaDataEditorComponent.vue
+++ b/frontend/src/components/FileMetaDataEditorComponent.vue
@@ -16,7 +16,7 @@
       <input
         type="text"
         class="flex-grow-1 border-0"
-        placeholder="Author"
+        placeholder="Enter to input author"
         @keyup.enter="addAuthor"
       />
     </ul>

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -97,6 +97,7 @@
         type="button"
         class="btn"
         @click.prevent="deleteFile(props.renderId, props.clientVisibleFile.file)"
+        title="Delete File"
       >
         <font-awesome-icon :icon="['fas', 'trash']" />
       </button>
@@ -106,14 +107,15 @@
         class="btn"
         @click.prevent="inSingleFileEditMode = true"
         :disabled="!props.clientVisibleFile.file.isEditable"
+        title="Edit metadata"
       >
         <font-awesome-icon :icon="['fas', 'file-pen']" />
       </button>
       <div v-show="!inEditMode && inSingleFileEditMode">
-        <button type="button" class="btn" @click.prevent="saveMetadata">
+        <button type="button" class="btn" @click.prevent="saveMetadata" title="Save change">
           <font-awesome-icon :icon="['fas', 'file-arrow-down']" />
         </button>
-        <button type="button" class="btn" @click.prevent="exitEditing">
+        <button type="button" class="btn" @click.prevent="exitEditing" title="Discard change">
           <font-awesome-icon :icon="['fas', 'file-excel']" />
         </button>
       </div>

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -163,15 +163,12 @@ watch(toolTipsElement, (newValue) => {
   }
 })
 
-watch(
-  props.clientVisibleFile,
-  (newValue) => {
-    metaDataFormModal.value.title = newValue.file.title
-    metaDataFormModal.value.description = newValue.file.description ?? ''
-    metaDataFormModal.value.authors = newValue.file.authors ?? []
-    metaDataFormModal.value.filename = newValue.file.filename
-  },
-)
+watch(props.clientVisibleFile, (newValue) => {
+  metaDataFormModal.value.title = newValue.file.title
+  metaDataFormModal.value.description = newValue.file.description ?? ''
+  metaDataFormModal.value.authors = newValue.file.authors ?? []
+  metaDataFormModal.value.filename = newValue.file.filename
+})
 
 async function toggleSelectFile(key: string) {
   emit('toggleSelectFile', key)

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -140,7 +140,7 @@ const inSingleFileEditMode = ref(false)
 const emit = defineEmits<{
   toggleSelectFile: [key: string]
   deleteFile: [key: string, file: NautilusFile]
-  updateFileMetadata: [renderId: string, id: string, metadata: FileMetadataForm]
+  updateFileMetadataStatus: [renderId: string, id: string, metadata: FileMetadataForm]
   updateSingleFileMetadata: [renderId: string, id: string, metadata: FileMetadataForm]
 }>()
 
@@ -202,7 +202,7 @@ function handleTitleInput(event: Event) {
 function updateFileMetadata() {
   if (props.inEditMode) {
     emit(
-      'updateFileMetadata',
+      'updateFileMetadataStatus',
       props.renderId,
       props.clientVisibleFile.file.id,
       metadataFormModal.value

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -10,7 +10,7 @@
       />
     </th>
     <td class="align-middle">
-      <div v-if="!isEditMode">
+      <div v-if="!inEditing">
         <span class="d-inline-block text-truncate file-title">
           {{ props.clientVisibleFile.file.title }}
         </span>
@@ -50,7 +50,7 @@
       </span>
     </td>
     <td class="align-middle">
-      <div v-if="!isEditMode">
+      <div v-if="!inEditing">
         <div
           class="position-relative"
           @mouseover.prevent="upHere = true"
@@ -88,7 +88,7 @@
       </div>
     </td>
     <td class="align-middle">
-      <div v-if="!isEditMode">
+      <div v-if="!inEditing">
         <button
           type="button"
           class="btn"
@@ -99,7 +99,7 @@
         <button
           type="button"
           class="btn"
-          @click.prevent="isEditMode = true"
+          @click.prevent="emit('updateEditingStatus', renderKey)"
           :disabled="!props.clientVisibleFile.file.isEditable"
         >
           <font-awesome-icon :icon="['fas', 'file-pen']" />
@@ -133,6 +133,7 @@ const props = defineProps<{
   isSelected: boolean
   renderKey: string
   clientVisibleFile: ClientVisibleFile
+  editingFileId: string | null
 }>()
 const toolTipsElement: Ref<Element | null> = ref(null)
 const upHere = ref(false)
@@ -140,8 +141,8 @@ const emit = defineEmits<{
   toggleSelectFile: [key: string]
   deleteFile: [key: string, file: FileClass]
   updateFileMetadata: [id: string, metadata: FileMetadataForm]
+  updateEditingStatus: [id: string | null]
 }>()
-const isEditMode = ref(false)
 
 const metaDataFormModal: Ref<FileMetadataForm> = ref({
   title: props.clientVisibleFile.file.title,
@@ -155,6 +156,9 @@ const fileUploadedDate = computed(() =>
 )
 const authors = computed(() =>
   props.clientVisibleFile.file.authors?.reduce((prev, author) => prev + author + ',', '')
+)
+const inEditing = computed(
+  () => props.editingFileId != null && props.editingFileId == props.renderKey
 )
 
 watch(toolTipsElement, (newValue) => {
@@ -179,7 +183,7 @@ async function deleteFile(key: string, file: FileClass) {
 }
 
 async function saveMetadata() {
-  isEditMode.value = false
+  emit('updateEditingStatus', null)
   emit('updateFileMetadata', props.clientVisibleFile.file.id, metaDataFormModal.value)
 }
 

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -121,10 +121,10 @@
 import {
   FileStatus,
   humanifyFileSize,
-  FileClass,
   type ClientVisibleFile,
   type FileMetadataForm,
-  type MetadataEditorFormType
+  type MetadataEditorFormType,
+  NautilusFile
 } from '@/constants'
 import { fromMime } from 'human-filetypes'
 import moment from 'moment'
@@ -142,7 +142,7 @@ const toolTipsElement: Ref<Element | null> = ref(null)
 const upHere = ref(false)
 const emit = defineEmits<{
   toggleSelectFile: [key: string]
-  deleteFile: [key: string, file: FileClass]
+  deleteFile: [key: string, file: NautilusFile]
   updateFileMetadata: [renderId: string, id: string, metadata: FileMetadataForm]
   updateEditingStatus: [id: string | null]
 }>()
@@ -181,7 +181,7 @@ async function toggleSelectFile(key: string) {
   emit('toggleSelectFile', key)
 }
 
-async function deleteFile(key: string, file: FileClass) {
+async function deleteFile(key: string, file: NautilusFile) {
   emit('deleteFile', key, file)
 }
 

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -121,7 +121,7 @@
 import {
   FileStatus,
   humanifyFileSize,
-  type File,
+  FileClass,
   type ClientVisibleFile,
   type FileMetadataForm,
   type MetadataEditorFormType
@@ -141,7 +141,7 @@ const toolTipsElement: Ref<Element | null> = ref(null)
 const upHere = ref(false)
 const emit = defineEmits<{
   toggleSelectFile: [key: string]
-  deleteFile: [key: string, file: File]
+  deleteFile: [key: string, file: FileClass]
   updateFileMetadata: [id: string, metadata: FileMetadataForm]
 }>()
 const isEditMode = ref(false)
@@ -170,7 +170,7 @@ async function toggleSelectFile(key: string) {
   emit('toggleSelectFile', key)
 }
 
-async function deleteFile(key: string, file: File) {
+async function deleteFile(key: string, file: FileClass) {
   emit('deleteFile', key, file)
 }
 

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -193,9 +193,7 @@ function handleTitleInput(event: Event) {
   event.preventDefault()
   const target = event.target as HTMLInputElement
   const value = target.value.trim()
-  if (value.length != 0) {
-    metadataFormModal.value.title = value
-  }
+  metadataFormModal.value.title = value
   updateFileMetadata()
 }
 

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -66,18 +66,8 @@
           @mouseover.prevent="upHere = true"
           @mouseleave.prevent="upHere = false"
         >
-          {{
-            props.clientVisibleFile.file.authors != undefined &&
-            props.clientVisibleFile.file.authors!.length != 0
-              ? `Authors; `
-              : ''
-          }}
-          {{
-            props.clientVisibleFile.file.description != undefined &&
-            props.clientVisibleFile.file.description != ''
-              ? `Description; `
-              : ''
-          }}
+          {{ isAuthorsAvailable ? `Authors; ` : '' }}
+          {{ isDescriptionAvailable ? `Description; ` : '' }}
           <div v-show="upHere" class="card position-absolute bottom-0 start-0 metadata-card">
             <div class="card-body">
               <div class="card-title custom-title">Description:</div>
@@ -167,6 +157,18 @@ const fileUploadedDate = computed(() =>
 
 const authors = computed(() =>
   props.clientVisibleFile.file.authors?.reduce((prev, author) => prev + author + ',', '')
+)
+
+const isAuthorsAvailable = computed(
+  () =>
+    props.clientVisibleFile.file.authors != undefined &&
+    props.clientVisibleFile.file.authors!.length != 0
+)
+
+const isDescriptionAvailable = computed(
+  () =>
+    props.clientVisibleFile.file.description != undefined &&
+    props.clientVisibleFile.file.description != ''
 )
 
 watch(toolTipsElement, (newValue) => {

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -65,16 +65,23 @@
       </div>
     </td>
     <td class="align-middle">
-      <button
-        type="button"
-        class="btn"
-        @click.prevent="deleteFile(props.renderKey, props.clientVisibleFile.file)"
-      >
-        <font-awesome-icon :icon="['fas', 'trash']" />
-      </button>
-      <button type="button" class="btn" v-if="props.showEditButton">
-        <font-awesome-icon :icon="['fas', 'file-pen']" />
-      </button>
+      <div v-if="!isEditMode">
+        <button
+          type="button"
+          class="btn"
+          @click.prevent="deleteFile(props.renderKey, props.clientVisibleFile.file)"
+        >
+          <font-awesome-icon :icon="['fas', 'trash']" />
+        </button>
+        <button type="button" class="btn" @click.prevent="isEditMode = true">
+          <font-awesome-icon :icon="['fas', 'file-pen']" />
+        </button>
+      </div>
+      <div v-else>
+        <button type="button" class="btn" @click.prevent="saveMetadata">
+          <font-awesome-icon :icon="['fas', 'file-arrow-down']" />
+        </button>
+      </div>
     </td>
   </tr>
 </template>
@@ -90,7 +97,6 @@ const props = defineProps<{
   isSelected: boolean
   renderKey: string
   clientVisibleFile: ClientVisibleFile
-  showEditButton: boolean
 }>()
 const toolTipsElement: Ref<Element | null> = ref(null)
 const upHere = ref(false)
@@ -98,6 +104,8 @@ const emit = defineEmits<{
   toggleSelectFile: [key: string]
   deleteFile: [key: string, file: File]
 }>()
+const isEditMode = ref(false)
+
 const fileUploadedDate = computed(() =>
   moment.utc(props.clientVisibleFile.file.uploaded_on).local().format('MMM DD HH:mm')
 )
@@ -117,6 +125,10 @@ async function toggleSelectFile(key: string) {
 
 async function deleteFile(key: string, file: File) {
   emit('deleteFile', key, file)
+}
+
+async function saveMetadata() {
+  isEditMode.value = false
 }
 </script>
 

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -5,7 +5,7 @@
         class="form-check-input"
         type="checkbox"
         value=""
-        @change.prevent="toggleSelectFile(props.renderKey)"
+        @change.prevent="toggleSelectFile(props.renderId)"
         :checked="props.isSelected"
       />
     </th>
@@ -92,14 +92,14 @@
         <button
           type="button"
           class="btn"
-          @click.prevent="deleteFile(props.renderKey, props.clientVisibleFile.file)"
+          @click.prevent="deleteFile(props.renderId, props.clientVisibleFile.file)"
         >
           <font-awesome-icon :icon="['fas', 'trash']" />
         </button>
         <button
           type="button"
           class="btn"
-          @click.prevent="emit('updateEditingStatus', renderKey)"
+          @click.prevent="emit('updateEditingStatus', renderId)"
           :disabled="!props.clientVisibleFile.file.isEditable"
         >
           <font-awesome-icon :icon="['fas', 'file-pen']" />
@@ -134,7 +134,7 @@ import FileMetaDataEditorComponent from '@/components/FileMetaDataEditorComponen
 
 const props = defineProps<{
   isSelected: boolean
-  renderKey: string
+  renderId: string
   clientVisibleFile: ClientVisibleFile
   editingFileId: string | null
 }>()
@@ -143,7 +143,7 @@ const upHere = ref(false)
 const emit = defineEmits<{
   toggleSelectFile: [key: string]
   deleteFile: [key: string, file: FileClass]
-  updateFileMetadata: [id: string, metadata: FileMetadataForm]
+  updateFileMetadata: [renderId: string, id: string, metadata: FileMetadataForm]
   updateEditingStatus: [id: string | null]
 }>()
 
@@ -161,7 +161,7 @@ const authors = computed(() =>
   props.clientVisibleFile.file.authors?.reduce((prev, author) => prev + author + ',', '')
 )
 const inEditing = computed(
-  () => props.editingFileId != null && props.editingFileId == props.renderKey
+  () => props.editingFileId != null && props.editingFileId == props.renderId
 )
 
 watch(toolTipsElement, (newValue) => {
@@ -187,7 +187,12 @@ async function deleteFile(key: string, file: FileClass) {
 
 async function saveMetadata() {
   emit('updateEditingStatus', null)
-  emit('updateFileMetadata', props.clientVisibleFile.file.id, metaDataFormModal.value)
+  emit(
+    'updateFileMetadata',
+    props.renderId,
+    props.clientVisibleFile.file.id,
+    metaDataFormModal.value
+  )
 }
 
 async function updateMetadataForm(newValue: MetadataEditorFormType) {

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -109,6 +109,9 @@
         <button type="button" class="btn" @click.prevent="saveMetadata">
           <font-awesome-icon :icon="['fas', 'file-arrow-down']" />
         </button>
+        <button type="button" class="btn" @click.prevent="exitEditing">
+          <font-awesome-icon :icon="['fas', 'trash']" />
+        </button>
       </div>
     </td>
   </tr>
@@ -191,6 +194,10 @@ async function updateMetadataForm(newValue: MetadataEditorFormType) {
   metaDataFormModal.value.description = newValue.description
   metaDataFormModal.value.authors = newValue.authors
   metaDataFormModal.value.filename = newValue.filename
+}
+
+async function exitEditing() {
+  emit('updateEditingStatus', null)
 }
 </script>
 

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -100,10 +100,7 @@
           type="button"
           class="btn"
           @click.prevent="isEditMode = true"
-          :disabled="
-            props.clientVisibleFile.file.status == FileStatus.FAILURE ||
-            props.clientVisibleFile.file.status == FileStatus.UPLOADING
-          "
+          :disabled="props.clientVisibleFile.file.isEditable"
         >
           <font-awesome-icon :icon="['fas', 'file-pen']" />
         </button>

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -163,6 +163,16 @@ watch(toolTipsElement, (newValue) => {
   }
 })
 
+watch(
+  props.clientVisibleFile,
+  (newValue) => {
+    metaDataFormModal.value.title = newValue.file.title
+    metaDataFormModal.value.description = newValue.file.description ?? ''
+    metaDataFormModal.value.authors = newValue.file.authors ?? []
+    metaDataFormModal.value.filename = newValue.file.filename
+  },
+)
+
 async function toggleSelectFile(key: string) {
   emit('toggleSelectFile', key)
 }

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -100,7 +100,7 @@
           type="button"
           class="btn"
           @click.prevent="isEditMode = true"
-          :disabled="props.clientVisibleFile.file.isEditable"
+          :disabled="!props.clientVisibleFile.file.isEditable"
         >
           <font-awesome-icon :icon="['fas', 'file-pen']" />
         </button>

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -202,6 +202,10 @@ async function updateMetadataForm(newValue: MetadataEditorFormType) {
 }
 
 async function exitEditing() {
+  metaDataFormModal.value.title = props.clientVisibleFile.file.title
+  metaDataFormModal.value.description = props.clientVisibleFile.file.description ?? ''
+  metaDataFormModal.value.authors = props.clientVisibleFile.file.authors ?? []
+  metaDataFormModal.value.filename = props.clientVisibleFile.file.filename
   emit('updateEditingStatus', null)
 }
 </script>

--- a/frontend/src/components/FileTableRowComponent.vue
+++ b/frontend/src/components/FileTableRowComponent.vue
@@ -9,8 +9,10 @@
         :checked="props.isSelected"
       />
     </th>
-    <td class="align-middle">
-      {{ props.clientVisibleFile.file.filename }}
+    <td class="align-middle text-truncate">
+      <span class="d-inline-block text-truncate" style="max-width: 10em">
+        {{ props.clientVisibleFile.file.filename }}
+      </span>
     </td>
     <td class="align-middle">
       {{ humanifyFileSize(props.clientVisibleFile.file.filesize) }}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -87,3 +87,15 @@ export type CompareFunctionType = (
   a: [string, ClientVisibleFile],
   b: [string, ClientVisibleFile]
 ) => number
+
+export type FileMetadataForm = {
+  title: string
+  description: string
+  authors: string[]
+  filename: string
+}
+export interface MetadataEditorFormType {
+  description: string
+  authors: string[]
+  filename: string
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -73,7 +73,6 @@ export class NautilusFile implements File {
   }
 
   get isEditable(): boolean {
-    return true
     return this.status != FileStatus.FAILURE && this.status != FileStatus.UPLOADING
   }
 }

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -72,6 +72,22 @@ export class NautilusFile implements File {
     this.status = status
   }
 
+  public static fromFile(file: File): NautilusFile {
+    return new NautilusFile(
+      file.id,
+      file.project_id,
+      file.filename,
+      file.filesize,
+      file.title,
+      file.authors,
+      file.description,
+      file.uploaded_on,
+      file.hash,
+      file.type,
+      file.status
+    )
+  }
+
   get isEditable(): boolean {
     return this.status != FileStatus.FAILURE && this.status != FileStatus.UPLOADING
   }

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 import { partial } from 'filesize'
 
 export interface ClientVisibleFile {
-  file: FileClass
+  file: NautilusFile
   uploadedSize: number
   statusCode?: string
   statusText?: string
@@ -33,7 +33,7 @@ export interface File {
   type: string
   status: FileStatus
 }
-export class FileClass implements File {
+export class NautilusFile implements File {
   id: string
   project_id: string
   filename: string

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid'
 import { partial } from 'filesize'
 
 export interface ClientVisibleFile {
-  file: File
+  file: FileClass
   uploadedSize: number
   statusCode?: string
   statusText?: string
@@ -32,6 +32,50 @@ export interface File {
   hash: string
   type: string
   status: FileStatus
+}
+export class FileClass implements File {
+  id: string
+  project_id: string
+  filename: string
+  filesize: number
+  title: string
+  authors?: string[]
+  description?: string
+  uploaded_on: string
+  hash: string
+  type: string
+  status: FileStatus
+
+  public constructor(
+    id: string,
+    project_id: string,
+    filename: string,
+    filesize: number,
+    title: string,
+    authors: string[] | undefined,
+    description: string | undefined,
+    uploaded_on: string,
+    hash: string,
+    type: string,
+    status: FileStatus
+  ) {
+    this.id = id
+    this.project_id = project_id
+    this.filename = filename
+    this.filesize = filesize
+    this.title = title
+    this.authors = authors
+    this.description = description
+    this.uploaded_on = uploaded_on
+    this.hash = hash
+    this.type = type
+    this.status = status
+  }
+
+  get isEditable(): boolean {
+    return true
+    return this.status != FileStatus.FAILURE && this.status != FileStatus.UPLOADING
+  }
 }
 
 export enum FileStatus {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,6 +19,7 @@ import {
   faFile,
   faFileArrowDown
 } from '@fortawesome/free-solid-svg-icons'
+import { faCircleXmark as farCircleXmark } from '@fortawesome/free-regular-svg-icons'
 
 /* add icons to the library */
 library.add(
@@ -31,7 +32,8 @@ library.add(
   faCheck,
   faSort,
   faFile,
-  faFileArrowDown
+  faFileArrowDown,
+  farCircleXmark
 )
 
 import App from './App.vue'

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -16,11 +16,23 @@ import {
   faAngleDown,
   faCheck,
   faSort,
-  faFile
+  faFile,
+  faFileArrowDown
 } from '@fortawesome/free-solid-svg-icons'
 
 /* add icons to the library */
-library.add(faPlus, faMinus, faXmark, faTrash, faFilePen, faAngleDown, faCheck, faSort, faFile)
+library.add(
+  faPlus,
+  faMinus,
+  faXmark,
+  faTrash,
+  faFilePen,
+  faAngleDown,
+  faCheck,
+  faSort,
+  faFile,
+  faFileArrowDown
+)
 
 import App from './App.vue'
 import router from './router'

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -17,7 +17,8 @@ import {
   faCheck,
   faSort,
   faFile,
-  faFileArrowDown
+  faFileArrowDown,
+  faFileExcel
 } from '@fortawesome/free-solid-svg-icons'
 import { faCircleXmark as farCircleXmark } from '@fortawesome/free-regular-svg-icons'
 
@@ -33,7 +34,8 @@ library.add(
   faSort,
   faFile,
   faFileArrowDown,
-  farCircleXmark
+  farCircleXmark,
+  faFileExcel
 )
 
 import App from './App.vue'

--- a/frontend/src/views/CollectionsView.vue
+++ b/frontend/src/views/CollectionsView.vue
@@ -4,7 +4,7 @@
       <div class="col col-2 sticky-top sidebar">
         <SideBarComponent />
       </div>
-      <div class="col content d-flex flex-column justify-content-between">
+      <div class="col content d-flex flex-column justify-content-between overflow-hidden">
         <div>
           <ProjectView v-if="hasValidProjectId" />
         </div>

--- a/frontend/src/views/NotFoundView.vue
+++ b/frontend/src/views/NotFoundView.vue
@@ -20,7 +20,4 @@
 <script setup lang="ts">
 import FooterComponent from '@/components/FooterComponent.vue'
 import SloganComponent from '@/components/SloganComponent.vue'
-import FrequentlyAskedQuestions from '@/components/FrequentlyAskedQuestions.vue'
-import DragToStartProjectComponent from '@/components/DragToStartProjectComponent.vue'
-import StatementsComponent from '@/components/StatementsComponent.vue'
 </script>

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -69,6 +69,8 @@
                 :render-key="key"
                 :client-visible-file="file"
                 :is-selected="selectedFiles.has(key)"
+                :editing-file-id="editingFileId"
+                @update-editing-status="updateFileEditingStatus"
                 @toggle-select-file="toggleSelectFile"
                 @delete-file="deleteSingleFile"
                 @update-file-metadata="updateFilesMetadata"
@@ -107,6 +109,7 @@ import { updateProjects } from '@/utils'
 
 const isActive = ref(false)
 const isEditMode = ref(false)
+const editingFileId: Ref<string | null> = ref(null)
 const isShowed = ref(true)
 const storeApp = useAppStore()
 const storeProject = useProjectStore()
@@ -400,6 +403,9 @@ async function updateSingleFileMetadata(
   files.value.get(clientFileId)!.file.description = newMetaData.description
   files.value.get(clientFileId)!.file.authors = newMetaData.authors
   files.value.get(clientFileId)!.file.filename = newMetaData.filename
+}
+function updateFileEditingStatus(newId: string | null) {
+  editingFileId.value = newId
 }
 </script>
 

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -69,7 +69,6 @@
                 :render-key="key"
                 :client-visible-file="file"
                 :is-selected="selectedFiles.has(key)"
-                :show-edit-button="isEditMode"
                 @toggle-select-file="toggleSelectFile"
                 @delete-file="deleteSingleFile"
               />

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -386,11 +386,11 @@ async function updateSingleFileMetadata(
   fileId: string,
   newMetaData: FileMetadataForm
 ) {
-  if (newMetaData.title == '') {
+  if (newMetaData.title.trim().length == 0) {
     storeApp.alertsWarning("Can not update file's metadata, since title is empty")
     return
   }
-  if (newMetaData.filename == '') {
+  if (newMetaData.filename.trim().length == 0) {
     storeApp.alertsWarning("Can not update file's metadata, since filename is empty")
     return
   }

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -372,10 +372,10 @@ async function updateFilesMetadata(
         }
       }
     } else {
-      for (const id of selectedFiles.value.keys()) {
-        const file = files.value.get(id)
+      for (const renderId of selectedFiles.value.keys()) {
+        const file = files.value.get(renderId)
         if (file != undefined && file.file.isEditable) {
-          updateSingleFileMetadata(file.file.id, file.file.id, newMetadata)
+          updateSingleFileMetadata(renderId, file.file.id, newMetadata)
         }
       }
     }

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -95,7 +95,7 @@ import FileTableHeaderComponent from '@/components/FileTableHeaderComponent.vue'
 import {
   FileStatus,
   type File,
-  FileClass,
+  NautilusFile,
   type ClientVisibleFile,
   humanifyFileSize,
   type CompareFunctionType,
@@ -121,7 +121,7 @@ const selectedFiles: Ref<Map<string, boolean>> = ref(new Map())
 const totalSize = computed(() =>
   Array.from(files.value.values()).reduce((pre, element) => pre + element.file.filesize, 0)
 )
-const toBeDeletedFiles: Ref<Map<string, FileClass>> = ref(new Map())
+const toBeDeletedFiles: Ref<Map<string, NautilusFile>> = ref(new Map())
 const compareFunction: Ref<CompareFunctionType> = ref((a, b) =>
   a[1].file.uploaded_on > b[1].file.uploaded_on ? 1 : -1
 )
@@ -157,7 +157,7 @@ function updateIsActive(newValue: boolean) {
 }
 
 async function getAllFiles(projectId: string | null) {
-  var result: FileClass[] = []
+  var result: NautilusFile[] = []
   if (projectId == null) {
     return result
   }
@@ -165,7 +165,7 @@ async function getAllFiles(projectId: string | null) {
     const reponse = await storeApp.axiosInstance.get<File[]>(`/projects/${projectId}/files`)
     for (const file of reponse.data) {
       result.push(
-        new FileClass(
+        new NautilusFile(
           file.id,
           file.project_id,
           file.filename,
@@ -193,7 +193,7 @@ async function uploadFiles(uploadFiles: FileList) {
   }
   const uploadFileRequestsList = []
   for (const uploadFile of uploadFiles) {
-    const newFile: FileClass = new FileClass(
+    const newFile: NautilusFile = new NautilusFile(
       storeApp.constants.genFakeId,
       storeProject.lastProjectId,
       uploadFile.name,
@@ -226,7 +226,7 @@ async function uploadFiles(uploadFiles: FileList) {
         .then((response) => {
           if (files.value.has(newFile.id)) {
             const data = response.data
-            files.value.get(newFile.id)!.file = new FileClass(
+            files.value.get(newFile.id)!.file = new NautilusFile(
               data.id,
               data.project_id,
               data.filename,
@@ -276,7 +276,7 @@ async function dropFilesHandler(fileList: FileList, uploadFileSize: number) {
 }
 
 async function deleteFiles() {
-  const deletedFiles: FileClass[] = []
+  const deletedFiles: NautilusFile[] = []
 
   for (const [key, file] of toBeDeletedFiles.value) {
     try {
@@ -302,7 +302,7 @@ async function deleteFiles() {
   }
 }
 
-async function deleteSingleFile(key: string, file: FileClass) {
+async function deleteSingleFile(key: string, file: NautilusFile) {
   toBeDeletedFiles.value.clear()
   toBeDeletedFiles.value.set(key, file)
   storeModal.showModal(

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -338,6 +338,9 @@ function updateCompareFunction(newFunction: CompareFunctionType) {
 }
 
 async function exitEditModeHandler() {
+  if (!inEditMode.value) {
+    return
+  }
   const changeList = []
 
   for (const [key, element] of beUpdatedFile.value.entries()) {

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -29,27 +29,31 @@
         <div>
           <div class="d-flex flex-row-reverse">
             <div class="btn-group btn-group-sm custom-btn-outline-primary" role="group">
-              <input
-                type="radio"
-                class="btn-check"
-                name="btnradio"
-                id="edit"
-                autocomplete="off"
-                @change="inEditMode = true"
-                :checked="inEditMode"
-              />
-              <label class="btn btn-outline-primary" for="edit">Edit</label>
+              <label class="btn btn-outline-primary" for="edit" :class="{ active: inEditMode }">
+                <input
+                  type="radio"
+                  class="btn-check"
+                  name="btnradio"
+                  id="edit"
+                  autocomplete="off"
+                  @click.prevent="inEditMode = true"
+                  :checked="inEditMode"
+                />
+                Edit
+              </label>
 
-              <input
-                type="radio"
-                class="btn-check"
-                name="btnradio"
-                id="upload"
-                autocomplete="off"
-                @change="exitEditModeHandler"
-                :checked="!inEditMode"
-              />
-              <label class="btn btn-outline-primary" for="upload">Upload</label>
+              <label class="btn btn-outline-primary" for="upload" :class="{ active: !inEditMode }">
+                <input
+                  type="radio"
+                  class="btn-check"
+                  name="btnradio"
+                  id="upload"
+                  autocomplete="off"
+                  @click.prevent="exitEditModeHandler"
+                  :checked="!inEditMode"
+                />
+                Upload
+              </label>
             </div>
           </div>
           <table class="table">
@@ -335,19 +339,25 @@ function updateCompareFunction(newFunction: CompareFunctionType) {
 
 async function exitEditModeHandler() {
   const changeList = []
+
   for (const [key, element] of beUpdatedFile.value.entries()) {
     if (files.value.get(key) != undefined) {
       changeList.push(element.metadata.title)
     }
   }
-  storeModal.showModal(
-    'Are you sure you want to change those files:',
-    'Change',
-    'Discard',
-    updateBeUpdatedFilesMetadata,
-    async () => {},
-    changeList
-  )
+
+  if (changeList.length == 0) {
+    inEditMode.value = false
+  } else {
+    storeModal.showModal(
+      'Are you sure you want to change those files:',
+      'Change',
+      'Discard',
+      updateBeUpdatedFilesMetadata,
+      async () => {},
+      changeList
+    )
+  }
 }
 async function updateBeUpdatedFilesMetadata() {
   for (const [key, element] of beUpdatedFile.value.entries()) {

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -164,21 +164,7 @@ async function getAllFiles(projectId: string | null) {
   try {
     const reponse = await storeApp.axiosInstance.get<File[]>(`/projects/${projectId}/files`)
     for (const file of reponse.data) {
-      result.push(
-        new NautilusFile(
-          file.id,
-          file.project_id,
-          file.filename,
-          file.filesize,
-          file.title,
-          file.authors,
-          file.description,
-          file.uploaded_on,
-          file.hash,
-          file.type,
-          file.status
-        )
-      )
+      result.push(NautilusFile.fromFile(file))
     }
   } catch (error: any) {
     console.log('Unable to retrieve the files info', error)
@@ -225,20 +211,8 @@ async function uploadFiles(uploadFiles: FileList) {
         .post<File>(`/projects/${storeProject.lastProjectId}/files`, requestData, config)
         .then((response) => {
           if (files.value.has(newFile.id)) {
-            const data = response.data
-            files.value.get(newFile.id)!.file = new NautilusFile(
-              data.id,
-              data.project_id,
-              data.filename,
-              data.filesize,
-              data.title,
-              data.authors,
-              data.description,
-              data.uploaded_on,
-              data.hash,
-              data.type,
-              data.status
-            )
+            const uploadedFile = response.data
+            files.value.get(newFile.id)!.file = NautilusFile.fromFile(uploadedFile)
           }
         })
         .catch((error) => {

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -354,7 +354,9 @@ async function exitEditModeHandler() {
       'Change',
       'Discard',
       updateBeUpdatedFilesMetadata,
-      async () => {},
+      async () => {
+        inEditMode.value = false
+      },
       changeList
     )
   }

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -359,6 +359,7 @@ async function exitEditModeHandler() {
     )
   }
 }
+
 async function updateBeUpdatedFilesMetadata() {
   for (const [key, element] of beUpdatedFile.value.entries()) {
     if (files.value.get(key) != undefined) {
@@ -368,6 +369,7 @@ async function updateBeUpdatedFilesMetadata() {
   inEditMode.value = false
   beUpdatedFile.value.clear()
 }
+
 async function updateFileMetadata(renderId: string, fileId: string, newMetaData: FileMetadataForm) {
   beUpdatedFile.value.set(renderId, { fileId: fileId, metadata: newMetaData })
   console.log(beUpdatedFile.value)

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -35,8 +35,8 @@
                 name="btnradio"
                 id="edit"
                 autocomplete="off"
-                @change="isEditMode = true"
-                :checked="isEditMode"
+                @change="inEditMode = true"
+                :checked="inEditMode"
               />
               <label class="btn btn-outline-primary" for="edit">Edit</label>
 
@@ -46,8 +46,8 @@
                 name="btnradio"
                 id="upload"
                 autocomplete="off"
-                @change="isEditMode = false"
-                :checked="!isEditMode"
+                @change="inEditMode = false"
+                :checked="!inEditMode"
               />
               <label class="btn btn-outline-primary" for="upload">Upload</label>
             </div>
@@ -69,8 +69,7 @@
                 :render-id="renderId"
                 :client-visible-file="file"
                 :is-selected="selectedFiles.has(renderId)"
-                :editing-file-id="editingFileId"
-                @update-editing-status="updateFileEditingStatus"
+                :in-edit-mode="inEditMode"
                 @toggle-select-file="toggleSelectFile"
                 @delete-file="deleteSingleFile"
                 @update-file-metadata="updateFilesMetadata"
@@ -108,8 +107,7 @@ import { storeToRefs } from 'pinia'
 import { updateProjects } from '@/utils'
 
 const isActive = ref(false)
-const isEditMode = ref(false)
-const editingFileId: Ref<string | null> = ref(null)
+const inEditMode = ref(false)
 const isShowed = ref(true)
 const storeApp = useAppStore()
 const storeProject = useProjectStore()
@@ -336,7 +334,8 @@ async function updateFilesMetadata(
   fileId: string,
   newMetadata: FileMetadataForm
 ) {
-  if (isEditMode.value == false) {
+  console.log('HHHH')
+  if (inEditMode.value == false) {
     updateSingleFileMetadata(renderId, fileId, newMetadata)
   } else {
     if (selectedFiles.value.size == 0) {
@@ -382,10 +381,6 @@ async function updateSingleFileMetadata(
   files.value.get(clientFileId)!.file.description = newMetaData.description
   files.value.get(clientFileId)!.file.authors = newMetaData.authors
   files.value.get(clientFileId)!.file.filename = newMetaData.filename
-}
-
-function updateFileEditingStatus(newId: string | null) {
-  editingFileId.value = newId
 }
 </script>
 

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -76,7 +76,7 @@
                 :in-edit-mode="inEditMode"
                 @toggle-select-file="toggleSelectFile"
                 @delete-file="deleteSingleFile"
-                @update-file-metadata="updateFileMetadata"
+                @update-file-metadata="updateFileMetadataStatus"
                 @update-single-file-metadata="updateSingleFileMetadata"
               />
             </tbody>
@@ -370,9 +370,12 @@ async function updateBeUpdatedFilesMetadata() {
   beUpdatedFile.value.clear()
 }
 
-async function updateFileMetadata(renderId: string, fileId: string, newMetaData: FileMetadataForm) {
+async function updateFileMetadataStatus(
+  renderId: string,
+  fileId: string,
+  newMetaData: FileMetadataForm
+) {
   beUpdatedFile.value.set(renderId, { fileId: fileId, metadata: newMetaData })
-  console.log(beUpdatedFile.value)
 }
 
 async function updateSingleFileMetadata(

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -64,11 +64,11 @@
             </thead>
             <tbody>
               <FileTableRowComponent
-                v-for="[key, file] in sortedFiles"
-                :key="key"
-                :render-key="key"
+                v-for="[renderId, file] in sortedFiles"
+                :key="renderId"
+                :render-id="renderId"
                 :client-visible-file="file"
-                :is-selected="selectedFiles.has(key)"
+                :is-selected="selectedFiles.has(renderId)"
                 :editing-file-id="editingFileId"
                 @update-editing-status="updateFileEditingStatus"
                 @toggle-select-file="toggleSelectFile"
@@ -357,9 +357,13 @@ function updateCompareFunction(newFunction: CompareFunctionType) {
   compareFunction.value = newFunction
 }
 
-async function updateFilesMetadata(fileId: string, newMetadata: FileMetadataForm) {
+async function updateFilesMetadata(
+  renderId: string,
+  fileId: string,
+  newMetadata: FileMetadataForm
+) {
   if (isEditMode.value == false) {
-    updateSingleFileMetadata(fileId, fileId, newMetadata)
+    updateSingleFileMetadata(renderId, fileId, newMetadata)
   } else {
     if (selectedFiles.value.size == 0) {
       for (const [id, file] of files.value.entries()) {

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -381,6 +381,7 @@ async function updateFilesMetadata(
     }
   }
 }
+
 async function updateSingleFileMetadata(
   clientFileId: string,
   fileId: string,
@@ -408,6 +409,7 @@ async function updateSingleFileMetadata(
   files.value.get(clientFileId)!.file.authors = newMetaData.authors
   files.value.get(clientFileId)!.file.filename = newMetaData.filename
 }
+
 function updateFileEditingStatus(newId: string | null) {
   editingFileId.value = newId
 }

--- a/frontend/src/views/ProjectView.vue
+++ b/frontend/src/views/ProjectView.vue
@@ -76,7 +76,7 @@
                 :in-edit-mode="inEditMode"
                 @toggle-select-file="toggleSelectFile"
                 @delete-file="deleteSingleFile"
-                @update-file-metadata="updateFileMetadataStatus"
+                @update-file-metadata-status="updateFileMetadataStatus"
                 @update-single-file-metadata="updateSingleFileMetadata"
               />
             </tbody>


### PR DESCRIPTION
# Goal
The goal of this PR is to add an interface to Nautilus for modifying the file Metadata.
# Abstract
- [x] Single file metadata modification
- [x] multi files metadata modification

When users enable the edit mode, there are two situations:
1. users didn't select any files, and the change will apply on all files.
2. users selected some files, and  the change will apply on selected files.